### PR TITLE
Trying to clean up tempfile warnings

### DIFF
--- a/simpleyapsy/tests/file_getters/test_with_info_file.py
+++ b/simpleyapsy/tests/file_getters/test_with_info_file.py
@@ -31,7 +31,7 @@ class TestWithInfoFileGetter(unittest.TestCase):
         test_dir = tempfile.TemporaryDirectory()
         file_template = test_dir.name + 'plugin.{}'
         plugin_file = open(file_template.format('yapsy-plugin'), 'w+')
-        fake_python = open(file_template.format('py', 'w+')
+        fake_python = open(file_template.format('py', 'w+'))
 
         python_file_name = fake_python.name[:-3]
         yapsy_contents = """
@@ -49,7 +49,7 @@ class TestWithInfoFileGetter(unittest.TestCase):
         test_dir = tempfile.TemporaryDirectory()
         file_template = test_dir.name + 'plugin.{}'
         plugin_file = open(file_template.format('yapsy-plugin'), 'w+')
-        fake_python = open(file_template.format('py', 'w+')
+        fake_python = open(file_template.format('py', 'w+'))
 
         python_file_name = fake_python.name[:-3]
         yapsy_contents = """

--- a/simpleyapsy/tests/file_getters/test_with_info_file.py
+++ b/simpleyapsy/tests/file_getters/test_with_info_file.py
@@ -48,7 +48,7 @@ class TestWithInfoFileGetter(unittest.TestCase):
         self.assertNotEqual(info, [])
 
     def test_get_plugin_filepath(self):
-        with tempfile.TemporaryDirectory() as test_dir
+        with tempfile.TemporaryDirectory() as test_dir:
             file_template = os.path.join(test_dir.name, 'plugin.{}')
             plugin_file = open(file_template.format('yapsy-plugin'), 'w+')
             fake_python = open(file_template.format('py'), 'w+')

--- a/simpleyapsy/tests/file_getters/test_with_info_file.py
+++ b/simpleyapsy/tests/file_getters/test_with_info_file.py
@@ -30,7 +30,7 @@ class TestWithInfoFileGetter(unittest.TestCase):
 
     def test_get_plugin_info(self):
         with tempfile.TemporaryDirectory() as test_dir:
-            file_template = os.path.join(test_dir.name, 'plugin.{}')
+            file_template = os.path.join(test_dir, 'plugin.{}')
             plugin_file = open(file_template.format('yapsy-plugin'), 'w+')
             fake_python = open(file_template.format('py'), 'w+')
 
@@ -41,15 +41,14 @@ class TestWithInfoFileGetter(unittest.TestCase):
             Module = {}\n""".format(python_file_name)
 
             plugin_file.write(yapsy_contents)
-            plugin_file.seek(0)
             plugin_file.close()
             fake_python.close()
-            info = self.file_getter.get_plugin_infos(test_dir.name)
+            info = self.file_getter.get_plugin_infos(test_dir)
         self.assertNotEqual(info, [])
 
     def test_get_plugin_filepath(self):
         with tempfile.TemporaryDirectory() as test_dir:
-            file_template = os.path.join(test_dir.name, 'plugin.{}')
+            file_template = os.path.join(test_dir, 'plugin.{}')
             plugin_file = open(file_template.format('yapsy-plugin'), 'w+')
             fake_python = open(file_template.format('py'), 'w+')
 
@@ -60,8 +59,7 @@ class TestWithInfoFileGetter(unittest.TestCase):
             Module = {}\n""".format(python_file_name)
 
             plugin_file.write(yapsy_contents)
-            plugin_file.seek(0)
             plugin_file.close()
             fake_python.close()
-            files = self.file_getter.get_plugin_filepaths(test_dir.name)
+            files = self.file_getter.get_plugin_filepaths(test_dir)
         self.assertIn(fake_python.name, files)

--- a/simpleyapsy/tests/file_getters/test_with_info_file.py
+++ b/simpleyapsy/tests/file_getters/test_with_info_file.py
@@ -29,39 +29,39 @@ class TestWithInfoFileGetter(unittest.TestCase):
         self.assertFalse(unvalid_filepath)
 
     def test_get_plugin_info(self):
-        test_dir = tempfile.TemporaryDirectory()
-        file_template = os.path.join(test_dir.name, 'plugin.{}')
-        plugin_file = open(file_template.format('yapsy-plugin'), 'w+')
-        fake_python = open(file_template.format('py'), 'w+')
+        with tempfile.TemporaryDirectory() as test_dir:
+            file_template = os.path.join(test_dir.name, 'plugin.{}')
+            plugin_file = open(file_template.format('yapsy-plugin'), 'w+')
+            fake_python = open(file_template.format('py'), 'w+')
 
-        python_file_name = fake_python.name[:-3]
-        yapsy_contents = """
-        [Core]\n
-        Name = Test\n
-        Module = {}\n""".format(python_file_name)
+            python_file_name = fake_python.name[:-3]
+            yapsy_contents = """
+            [Core]\n
+            Name = Test\n
+            Module = {}\n""".format(python_file_name)
 
-        plugin_file.write(yapsy_contents)
-        plugin_file.seek(0)
-        plugin_file.close()
-        fake_python.close()
-        info = self.file_getter.get_plugin_infos(test_dir.name)
+            plugin_file.write(yapsy_contents)
+            plugin_file.seek(0)
+            plugin_file.close()
+            fake_python.close()
+            info = self.file_getter.get_plugin_infos(test_dir.name)
         self.assertNotEqual(info, [])
 
     def test_get_plugin_filepath(self):
-        test_dir = tempfile.TemporaryDirectory()
-        file_template = os.path.join(test_dir.name, 'plugin.{}')
-        plugin_file = open(file_template.format('yapsy-plugin'), 'w+')
-        fake_python = open(file_template.format('py'), 'w+')
-        
-        python_file_name = fake_python.name[:-3]
-        yapsy_contents = """
-        [Core]\n
-        Name = Test\n
-        Module = {}\n""".format(python_file_name)
+        with tempfile.TemporaryDirectory() as test_dir
+            file_template = os.path.join(test_dir.name, 'plugin.{}')
+            plugin_file = open(file_template.format('yapsy-plugin'), 'w+')
+            fake_python = open(file_template.format('py'), 'w+')
 
-        plugin_file.write(yapsy_contents)
-        plugin_file.seek(0)
-        plugin_file.close()
-        fake_python.close()
-        files = self.file_getter.get_plugin_filepaths(test_dir.name)
+            python_file_name = fake_python.name[:-3]
+            yapsy_contents = """
+            [Core]\n
+            Name = Test\n
+            Module = {}\n""".format(python_file_name)
+
+            plugin_file.write(yapsy_contents)
+            plugin_file.seek(0)
+            plugin_file.close()
+            fake_python.close()
+            files = self.file_getter.get_plugin_filepaths(test_dir.name)
         self.assertIn(fake_python.name, files)

--- a/simpleyapsy/tests/file_getters/test_with_info_file.py
+++ b/simpleyapsy/tests/file_getters/test_with_info_file.py
@@ -39,7 +39,6 @@ class TestWithInfoFileGetter(unittest.TestCase):
         [Core]\n
         Name = Test\n
         Module = {}\n""".format(python_file_name)
-        yapsy_contents = bytes(yapsy_contents, 'utf-8')
 
         plugin_file.write(yapsy_contents)
         plugin_file.seek(0)
@@ -57,7 +56,6 @@ class TestWithInfoFileGetter(unittest.TestCase):
         [Core]\n
         Name = Test\n
         Module = {}\n""".format(python_file_name)
-        yapsy_contents = bytes(yapsy_contents, 'utf-8')
 
         plugin_file.write(yapsy_contents)
         plugin_file.seek(0)

--- a/simpleyapsy/tests/file_getters/test_with_info_file.py
+++ b/simpleyapsy/tests/file_getters/test_with_info_file.py
@@ -29,11 +29,9 @@ class TestWithInfoFileGetter(unittest.TestCase):
 
     def test_get_plugin_info(self):
         test_dir = tempfile.TemporaryDirectory()
-        plugin_file = tempfile.NamedTemporaryFile(suffix='.yapsy-plugin',
-                                                  dir=test_dir.name)
-
-        fake_python = tempfile.NamedTemporaryFile(suffix='.py',
-                                                  dir=test_dir.name)
+        file_template = test_dir.name + 'plugin.{}'
+        plugin_file = open(file_template.format('yapsy-plugin'), 'w+')
+        fake_python = open(file_template.format('py', 'w+')
 
         python_file_name = fake_python.name[:-3]
         yapsy_contents = """
@@ -49,11 +47,9 @@ class TestWithInfoFileGetter(unittest.TestCase):
 
     def test_get_plugin_filepath(self):
         test_dir = tempfile.TemporaryDirectory()
-        plugin_file = tempfile.NamedTemporaryFile(suffix='.yapsy-plugin',
-                                                  dir=test_dir.name)
-
-        fake_python = tempfile.NamedTemporaryFile(suffix='.py',
-                                                  dir=test_dir.name)
+        file_template = test_dir.name + 'plugin.{}'
+        plugin_file = open(file_template.format('yapsy-plugin'), 'w+')
+        fake_python = open(file_template.format('py', 'w+')
 
         python_file_name = fake_python.name[:-3]
         yapsy_contents = """

--- a/simpleyapsy/tests/file_getters/test_with_info_file.py
+++ b/simpleyapsy/tests/file_getters/test_with_info_file.py
@@ -42,6 +42,8 @@ class TestWithInfoFileGetter(unittest.TestCase):
 
         plugin_file.write(yapsy_contents)
         plugin_file.seek(0)
+        plugin_file.close()
+        fake_python.close()
         info = self.file_getter.get_plugin_infos(test_dir.name)
         self.assertNotEqual(info, [])
 
@@ -50,7 +52,7 @@ class TestWithInfoFileGetter(unittest.TestCase):
         file_template = os.path.join(test_dir.name, 'plugin.{}')
         plugin_file = open(file_template.format('yapsy-plugin'), 'w+')
         fake_python = open(file_template.format('py'), 'w+')
-
+        
         python_file_name = fake_python.name[:-3]
         yapsy_contents = """
         [Core]\n
@@ -59,6 +61,7 @@ class TestWithInfoFileGetter(unittest.TestCase):
 
         plugin_file.write(yapsy_contents)
         plugin_file.seek(0)
-
+        plugin_file.close()
+        fake_python.close()
         files = self.file_getter.get_plugin_filepaths(test_dir.name)
         self.assertIn(fake_python.name, files)

--- a/simpleyapsy/tests/file_getters/test_with_info_file.py
+++ b/simpleyapsy/tests/file_getters/test_with_info_file.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 import tempfile
 from simpleyapsy.file_getters import WithInfoFileGetter
@@ -29,9 +30,9 @@ class TestWithInfoFileGetter(unittest.TestCase):
 
     def test_get_plugin_info(self):
         test_dir = tempfile.TemporaryDirectory()
-        file_template = test_dir.name + 'plugin.{}'
+        file_template = os.path.join(test_dir.name, 'plugin.{}')
         plugin_file = open(file_template.format('yapsy-plugin'), 'w+')
-        fake_python = open(file_template.format('py', 'w+'))
+        fake_python = open(file_template.format('py'), 'w+')
 
         python_file_name = fake_python.name[:-3]
         yapsy_contents = """
@@ -47,9 +48,9 @@ class TestWithInfoFileGetter(unittest.TestCase):
 
     def test_get_plugin_filepath(self):
         test_dir = tempfile.TemporaryDirectory()
-        file_template = test_dir.name + 'plugin.{}'
+        file_template = os.path.join(test_dir.name, 'plugin.{}')
         plugin_file = open(file_template.format('yapsy-plugin'), 'w+')
-        fake_python = open(file_template.format('py', 'w+'))
+        fake_python = open(file_template.format('py'), 'w+')
 
         python_file_name = fake_python.name[:-3]
         yapsy_contents = """


### PR DESCRIPTION
Using a temporary dir and temporary file spams the travis ci log with a bunch of warnings/errors. This branch is an attempt to fix that.
