### PR TITLE
Interface API

### DIFF
--- a/simpleyapsy/directory_manager.py
+++ b/simpleyapsy/directory_manager.py
@@ -3,8 +3,9 @@ import site
 
 from simpleyapsy import util
 
+
 class DirectoryManager(object):
-    def __init__(self, 
+    def __init__(self,
                  plugin_directories=set(),
                  recursive=True):
 

--- a/simpleyapsy/directory_manager.py
+++ b/simpleyapsy/directory_manager.py
@@ -1,0 +1,47 @@
+import os
+import site
+
+from simpleyapsy import util
+
+class DirectoryManager(object):
+    def __init__(self, 
+                 plugin_directories=set(),
+                 recursive=True):
+
+        if plugin_directories == set():
+            plugin_directories = set()
+            plugin_directories.add(os.path.dirname(__file__))
+
+        self.plugin_directories = plugin_directories
+        self.recursive = recursive
+
+    def add_directories(self, paths):
+        paths = util.return_list(paths)
+        unique_paths = set.union(set(paths), set(self.plugin_directories))
+        self.plugin_directories = unique_paths
+
+    def set_directories(self, paths):
+        paths = util.return_list(paths)
+        self.plugin_directories = set(paths)
+
+    def add_site_packages_paths(self):
+        self.add_plugin_directories(site.getsitepackages())
+
+    def get_directories(self):
+        self._plugin_dirs_to_absolute_paths()
+        if not self.recursive:
+            return self.plugin_directories
+        # TODO: CLEANUP
+        recursive_dirs = []
+        for dir in self.plugin_directories:
+            walk_iter = os.walk(dir, followlinks=True)
+            walk_iter = [w[0] for w in walk_iter]
+            recursive_dirs.extend(walk_iter)
+        return recursive_dirs
+
+    def _plugin_dirs_to_absolute_paths(self):
+        # alias out to meet <80 character line pep req
+        abspath = os.path.abspath
+        self.plugin_directories = [abspath(x) for x in self.plugin_directories]
+        # casting to set removes dups, casting back to list for type
+        self.plugin_directories = set(self.plugin_directories)

--- a/simpleyapsy/file_locator.py
+++ b/simpleyapsy/file_locator.py
@@ -29,7 +29,7 @@ class FileLocator(object):
         """
         for directory in directories:
             # Can have more than one file getter
-            filepaths = self._file_getter_iterator_helper(dir_path)
+            filepaths = self._file_getter_iterator_helper(directory)
             self.plugin_files.add(filepaths)
 
         return self.plugin_files

--- a/simpleyapsy/file_locator.py
+++ b/simpleyapsy/file_locator.py
@@ -1,6 +1,3 @@
-import os
-import site
-
 from simpleyapsy.file_getters import WithInfoFileGetter
 from simpleyapsy import util
 
@@ -11,29 +8,10 @@ class FileLocator(object):
     to determine what files actually corresponds to plugins.
     """
     def __init__(self,
-                 file_getters=[WithInfoFileGetter('yapsy-plugin')],
-                 plugin_directories=[],
-                 recursive=True):
+                 file_getters=[WithInfoFileGetter('yapsy-plugin')]):
 
-        if plugin_directories == []:
-            plugin_directories = [os.path.dirname(__file__)]
-
-        self.plugin_directories = plugin_directories
         self.file_getters = file_getters
-        self.recursive = recursive
         self.plugin_files = set()
-
-    def add_plugin_directories(self, paths):
-        paths = util.return_list(paths)
-        unique_paths = set.union(set(paths), set(self.plugin_directories))
-        self.plugin_directories = list(unique_paths)
-
-    def set_plugin_directories(self, paths):
-        paths = util.return_list(paths)
-        self.plugin_directories = paths
-
-    def add_site_packages_paths(self):
-        self.add_plugin_directories(site.getsitepackages())
 
     def set_file_getters(self, file_getters):
         file_getters = util.return_list(file_getters)
@@ -43,21 +21,16 @@ class FileLocator(object):
         file_getters = util.return_list(file_getters)
         self.file_getters.extend(file_getters)
 
-    def locate_filepaths(self, directories=None):
+    def locate_filepaths(self, directories):
         """
         Walk through the plugins' places and look for plugins.
 
         Return the candidates and number of plugins found.
         """
-        self._plugin_dirs_to_absolute_paths()
-        for plugin_directory in self.plugin_directories:
-            # handle whether we're recursively looking through directories
-            dir_paths = self._get_dir_iterator(plugin_directory)
-
-            for dir_path in dir_paths:
-                # Can have more than one file getter
-                filepaths = self._file_getter_iterator_helper(dir_path)
-                self.plugin_files.add(filepaths)
+        for directory in directories:
+            # Can have more than one file getter
+            filepaths = self._file_getter_iterator_helper(dir_path)
+            self.plugin_files.add(filepaths)
 
         return self.plugin_files
 
@@ -74,21 +47,3 @@ class FileLocator(object):
             filepaths.update(plugin_paths)
 
         return filepaths
-
-    def _get_dir_iterator(self, directory):
-        """
-        Handles recursion
-        """
-        if self.recursive:
-            walk_iter = os.walk(directory, followlinks=True)
-            walk_iter = [w[0] for w in walk_iter]
-        else:
-            walk_iter = [directory]
-        return walk_iter
-
-    def _plugin_dirs_to_absolute_paths(self):
-        # alias out to meet <80 character line pep req
-        abspath = os.path.abspath
-        self.plugin_directories = [abspath(x) for x in self.plugin_directories]
-        # casting to set removes dups, casting back to list for type
-        self.plugin_directories = list(set(self.plugin_directories))

--- a/simpleyapsy/file_locator.py
+++ b/simpleyapsy/file_locator.py
@@ -43,7 +43,7 @@ class FileLocator(object):
         file_getters = util.return_list(file_getters)
         self.file_getters.extend(file_getters)
 
-    def locate_files(self):
+    def locate_filepaths(self, directories=None):
         """
         Walk through the plugins' places and look for plugins.
 

--- a/simpleyapsy/interface.py
+++ b/simpleyapsy/interface.py
@@ -30,17 +30,14 @@ class Interface(object):
     def add_file_getters(self, file_getters):
         self.file_locator.add_file_getters(file_getters)
 
-    def get_plugin_filepaths(self, directories=None):
-        if directories and self.managing_state:
-            self.add_plugin_directories(directories)
-            filepaths = self.file_locator.locate_filepaths()
-        elif directories:
-            filepaths = self.file_locator.locate_filepaths(directories)
-        elif self.managing_state:
-            filepaths = self.file_locator.locate_filepaths()
+    def locate_plugin_filepaths(self, directories=None):
+        if directories:
+            return self.file_locator.locate_filepaths(directories)
         else:
-            filepaths = self.file_locator.get_plugin_filepaths()
-        return filepaths
+            return self.file_locator.locate_filepaths()
+
+    def get_plugin_filepaths(self):
+        return self.file_locator.get_plugin_filepaths()
 
     def blacklist_filepaths(self, filepaths):
         self.module_loader.blacklist_filepaths(filepaths)
@@ -53,23 +50,20 @@ class Interface(object):
 
     def load_modules(self, filepaths=None):
         if filepaths is None:
-            filepaths = self.get_plugin_filepaths()
+            filepaths = self.locate_plugin_filepaths()
 
-        self.module_loader.load_modules(filepaths)
-        if self.managing_state:
-            modules = self.module_loader.get_loaded_modules()
-            self.plugin_manager.add_modules(modules)
+        return self.module_loader.load_modules(filepaths)
 
     def reload_modules(self, module_or_module_name):
         self.module_loader.reload_module(module_or_module_name)
 
-    def get_plugins(self):
-        if self.managing_state:
-            loaded_plugins = self.load_plugins()
-            self.plugin_manager.set_plugins(loaded_plugins)
+    def get_loaded_modules(self):
+        return self.module_loader.get_loaded_modules()
 
-        plugins = self.plugin_manager.get_plugins()
-        return plugins
+    def get_plugins_from_modules(self, modules=None):
+        if modules is None:
+            modules = self.load_modules()
+        return self.module_loader.get_plugins_from_modules(modules)
 
     def set_plugins(self, plugins):
         self.plugin_manager.set_plugins(plugins)

--- a/simpleyapsy/interface.py
+++ b/simpleyapsy/interface.py
@@ -1,6 +1,7 @@
 from .file_locator import FileLocator
 from .plugin_manager import PluginManager
 from .module_loader import ModuleLoader
+from .directory_manager import DirectoryManager
 
 
 class Interface(object):
@@ -14,15 +15,19 @@ class Interface(object):
         self.file_locator = file_locator
         self.module_loader = module_loader
         self.plugin_manager = plugin_manager
+        self.directory_manager = DirectoryManager()
 
     def add_plugin_directories(self, paths):
-        self.file_locator.add_plugin_directories(paths)
+        self.directory_manager.add_directories(paths)
 
     def set_plugin_directories(self, paths):
-        self.file_locator.set_plugin_directories(paths)
+        self.directory_manager.set_directories(paths)
+
+    def get_plugin_directories(self):
+        return self.directory_manager.get_directories()
 
     def track_site_package_paths(self):
-        self.file_locator.add_site_packages_paths()
+        self.directory_manager.add_site_packages_paths()
 
     def set_file_getters(self, file_getters):
         self.file_locator.set_file_getters(file_getters)
@@ -31,10 +36,9 @@ class Interface(object):
         self.file_locator.add_file_getters(file_getters)
 
     def locate_plugin_filepaths(self, directories=None):
-        if directories:
-            return self.file_locator.locate_filepaths(directories)
-        else:
-            return self.file_locator.locate_filepaths()
+        if directories is None:
+            directories = self.get_plugin_directories()
+        return self.file_locator.locate_filepaths(directories)
 
     def get_plugin_filepaths(self):
         return self.file_locator.get_plugin_filepaths()

--- a/simpleyapsy/interface.py
+++ b/simpleyapsy/interface.py
@@ -30,9 +30,17 @@ class Interface(object):
     def add_file_getters(self, file_getters):
         self.file_locator.add_file_getters(file_getters)
 
-    def get_plugin_locations(self):
-        located_plugins = self.file_locator.locate_plugins()
-        return located_plugins
+    def get_plugin_filepaths(self, directories=None):
+        if directories and self.managing_state:
+            self.add_plugin_directories(directories)
+            filepaths = self.file_locator.locate_filepaths()
+        elif directories:
+            filepaths = self.file_locator.locate_filepaths(directories)
+        elif self.managing_state:
+            filepaths = self.file_locator.locate_filepaths()
+        else:
+            filepaths = self.file_locator.get_plugin_filepaths()
+        return filepaths
 
     def blacklist_filepaths(self, filepaths):
         self.module_loader.blacklist_filepaths(filepaths)
@@ -45,7 +53,7 @@ class Interface(object):
 
     def load_modules(self, filepaths=None):
         if filepaths is None:
-            filepaths = self.file_locator.get_plugin_filepaths()
+            filepaths = self.get_plugin_filepaths()
 
         self.module_loader.load_modules(filepaths)
         if self.managing_state:

--- a/simpleyapsy/tests/test_directory_manager.py
+++ b/simpleyapsy/tests/test_directory_manager.py
@@ -1,0 +1,41 @@
+import os
+import unittest
+from simpleyapsy.directory_manager import DirectoryManager
+
+
+class TestDirectoryManager(unittest.TestCase):
+    def setUp(self):
+        self.directory_manager = DirectoryManager()
+
+    def test_add_plugin_directory(self):
+        test_dir = 'my/plugin/dir'
+        self.directory_manager.add_directories(test_dir)
+        self.assertIn(test_dir, self.directory_manager.plugin_directories)
+
+    def test_set_plugin_directory(self):
+        current_dirs = self.directory_manager.plugin_directories.pop()
+        test_dir = 'my/plugin/dir'
+        self.directory_manager.set_directories(test_dir)
+        self.assertIn(test_dir, self.directory_manager.plugin_directories)
+        self.assertNotIn(current_dirs, self.directory_manager.plugin_directories)
+
+    def test_get_dir_iterator_recursive(self):
+        directories = self.directory_manager.get_directories()
+        self.assertTrue(len(directories) > 1)
+
+    def test_get_dir_iterator_not_recursive(self):
+        # default dir is the package dir, which has multiple dirs
+        self.directory_manager.recursive = False
+        directories = self.directory_manager.get_directories()
+        self.assertEqual(len(directories), 1)
+
+    def test_plugin_paths_to_absolute(self):
+        self.directory_manager.set_directories('simpleyapsy')
+        plugin_dirs = self.directory_manager.plugin_directories
+        self.assertFalse(os.path.isabs(next(iter(plugin_dirs))))
+        self.directory_manager._plugin_dirs_to_absolute_paths()
+        plugin_dirs = self.directory_manager.plugin_directories
+        self.assertTrue(os.path.isabs(plugin_dirs.pop()))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/simpleyapsy/tests/test_directory_manager.py
+++ b/simpleyapsy/tests/test_directory_manager.py
@@ -17,7 +17,8 @@ class TestDirectoryManager(unittest.TestCase):
         test_dir = 'my/plugin/dir'
         self.directory_manager.set_directories(test_dir)
         self.assertIn(test_dir, self.directory_manager.plugin_directories)
-        self.assertNotIn(current_dirs, self.directory_manager.plugin_directories)
+        self.assertNotIn(current_dirs,
+                         self.directory_manager.plugin_directories)
 
     def test_get_dir_iterator_recursive(self):
         directories = self.directory_manager.get_directories()

--- a/simpleyapsy/tests/test_file_locator.py
+++ b/simpleyapsy/tests/test_file_locator.py
@@ -11,18 +11,6 @@ class TestFileLocator(unittest.TestCase):
     def setUp(self):
         self.file_locator = FileLocator()
 
-    def test_add_plugin_directory(self):
-        test_dir = 'my/plugin/dir'
-        self.file_locator.add_plugin_directories(test_dir)
-        self.assertIn(test_dir, self.file_locator.plugin_directories)
-
-    def test_set_plugin_directory(self):
-        current_dirs = self.file_locator.plugin_directories[0]
-        test_dir = 'my/plugin/dir'
-        self.file_locator.set_plugin_directories(test_dir)
-        self.assertIn(test_dir, self.file_locator.plugin_directories)
-        self.assertNotIn(current_dirs, self.file_locator.plugin_directories)
-
     def test_set_file_getters(self):
         current_file_getters = self.file_locator.file_getters[0]
         # Create a abstract object for testing
@@ -36,26 +24,6 @@ class TestFileLocator(unittest.TestCase):
         self.file_locator.add_file_getters(test_obj)
         self.assertIn(test_obj, self.file_locator.file_getters)
 
-    def test_get_dir_iterator_recursive(self):
-        dir = os.path.dirname(__file__)
-        test_dir = os.path.join(dir, '..')
-        walk_iter = self.file_locator._get_dir_iterator(test_dir)
-        self.assertNotEqual(len(walk_iter), 1)
-
-    def test_get_dir_iterator_not_recursive(self):
-        # assume home dir has dirs
-        test_dir = os.path.expanduser('~')
-        self.file_locator.recursive = False
-        walk_iter = self.file_locator._get_dir_iterator(test_dir)
-        self.assertEqual(len(walk_iter), 1)
-
-    def test_plugin_paths_to_absolute(self):
-        self.file_locator.set_plugin_directories('simpleyapsy')
-        plugin_dirs = self.file_locator.plugin_directories
-        self.assertFalse(os.path.isabs(plugin_dirs[0]))
-        self.file_locator._plugin_dirs_to_absolute_paths()
-        plugin_dirs = self.file_locator.plugin_directories
-        self.assertTrue(os.path.isabs(plugin_dirs[0]))
 
 
 if __name__ == '__main__':

--- a/simpleyapsy/tests/test_file_locator.py
+++ b/simpleyapsy/tests/test_file_locator.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 from simpleyapsy.file_locator import FileLocator
 
@@ -23,7 +22,6 @@ class TestFileLocator(unittest.TestCase):
         test_obj = TestClass()
         self.file_locator.add_file_getters(test_obj)
         self.assertIn(test_obj, self.file_locator.file_getters)
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Interface is made up of 3 (soon to be 4) state machines. Each state machine has one non-optional state and an optional state.

For `FileLocator` the non optional state are the file getters. The optional are the stored filepaths

For `ModuleLoader` the non optional state is the module parsers. The optional state is the loaded modules

For `PluginManager` the non optional state are the plugins. The optional state is likely the plugin filters

For the soon to be `InstanceManager` the non optioinal state are the instances. The optional state is likely to be the instance filters. 

This branch is to work through the implications of the optional state and the corresponding API changes. This should be tied closely to the Interface variable `auto_manage_state`
